### PR TITLE
Working version lacking one previous feature

### DIFF
--- a/PixivArtist.py
+++ b/PixivArtist.py
@@ -29,7 +29,7 @@ class PixivArtist:
         self.offset = offset
         self.limit = limit
         self.artistId = mid
-
+        
         if payload_body is not None:
             # detect if image count != 0
             if not fromImage:
@@ -40,8 +40,6 @@ class PixivArtist:
                 self.isLastPage = True
                 self.haveImages = True
 
-            # parse artist info
-            self.ParseInfo(payload_body, fromImage)
 
     def ParseMangaList(self, payload):
         if payload is not None and "mangaSeries" in payload:
@@ -76,24 +74,8 @@ class PixivArtist:
                     root = page["body"]["novel"]
                     self.artistId = root["user_id"]
                     self.artistToken = root["user_account"]
-                    self.artistName = root["user_name"]
-                else:
-                    # https://www.pixiv.net/ajax/user/1039353
-                    data = None
-                    if "pickup" in page and len(page["pickup"]) > 0:
-                        data = page["pickup"][0]
-
-                    if data is not None:
-                        self.artistId = data["userId"]
-                        # HELP: No unique name visible from this payload.
-                        # Necessary substitution must be found (maybe from first image?).
-                        self.artistToken = "broken_feature"
-                        self.artistName = data["userName"]
-
-                        avatar_data = data["user"]["profile_image_urls"]
-                        if avatar_data is not None and "medium" in avatar_data:
-                            self.artistAvatar = avatar_data["medium"].replace("_170", "")
-
+                    self.artistName = root["user_name"]                        
+                        
                 if "profile" in page:
                     if self.totalImages == 0:
                         if bookmark:

--- a/PixivArtist.py
+++ b/PixivArtist.py
@@ -37,6 +37,7 @@ class PixivArtist:
                 self.ParseMangaList(payload_body)
                 self.ParseNovelList(payload_body)
             else:
+                self.ParseInfo(page=payload_body, fromImage=fromImage)
                 self.isLastPage = True
                 self.haveImages = True
 
@@ -64,7 +65,7 @@ class PixivArtist:
                 self.ParseInfoFromImage(page)
             else:
                 # used in PixivBrowserFactory.getMemberInfoWhitecube()
-                # webrpc method
+                # webrpc method https://www.pixiv.net/rpc/get_work.php?id=1039353
                 if "body" in page and "illust" in page["body"] and page["body"]["illust"]:
                     root = page["body"]["illust"]
                     self.artistId = root["illust_user_id"]
@@ -74,8 +75,8 @@ class PixivArtist:
                     root = page["body"]["novel"]
                     self.artistId = root["user_id"]
                     self.artistToken = root["user_account"]
-                    self.artistName = root["user_name"]                        
-                        
+                    self.artistName = root["user_name"]
+
                 if "profile" in page:
                     if self.totalImages == 0:
                         if bookmark:
@@ -86,6 +87,7 @@ class PixivArtist:
                         self.artistBackground = page["profile"]["background_image_url"]
 
     def ParseInfoFromImage(self, page):
+        # https://www.pixiv.net/ajax/illust/128949568
         self.artistId = page["userId"]
         self.artistToken = page["userAccount"]
         self.artistName = page["userName"]

--- a/PixivArtist.py
+++ b/PixivArtist.py
@@ -78,17 +78,17 @@ class PixivArtist:
                     self.artistToken = root["user_account"]
                     self.artistName = root["user_name"]
                 else:
-                    # https://app-api.pixiv.net/v1/user/detail?user_id=1039353
+                    # https://www.pixiv.net/ajax/user/1039353
                     data = None
-                    if "user" in page:
-                        data = page
-                    elif "illusts" in page and len(page["illusts"]) > 0:
-                        data = page["illusts"][0]
+                    if "pickup" in page and len(page["pickup"]) > 0:
+                        data = page["pickup"][0]
 
                     if data is not None:
-                        self.artistId = data["user"]["id"]
-                        self.artistToken = data["user"]["account"]
-                        self.artistName = data["user"]["name"]
+                        self.artistId = data["userId"]
+                        # HELP: No unique name visible from this payload.
+                        # Necessary substitution must be found (maybe from first image?).
+                        self.artistToken = "broken_feature"
+                        self.artistName = data["userName"]
 
                         avatar_data = data["user"]["profile_image_urls"]
                         if avatar_data is not None and "medium" in avatar_data:

--- a/PixivBrowserFactory.py
+++ b/PixivBrowserFactory.py
@@ -254,7 +254,7 @@ class PixivBrowser(mechanize.Browser):
                     try:
                         temp = self.open_with_retry(req)
                         read_page = temp.read()
-                        read_page = read_page.decode('utf8')
+                        read_page = read_page.decode('utf-8')
                         if enable_cache:
                             self._put_to_cache(url, read_page)
                         temp.close()
@@ -806,13 +806,14 @@ class PixivBrowser(mechanize.Browser):
             # https://www.pixiv.net/ajax/user/5238/illustmanga/tag?tag=R-18&offset=0&limit=48
             # https://www.pixiv.net/ajax/user/1813972/profile/all
             url = None
-            if len(tags) > 0:  # called from Download by tags
-                url = f'https://www.pixiv.net/ajax/user/{member_id}/illustmanga/tag?tag={tags}&offset={offset}&limit={limit}'
-            elif r18mode:
-                url = f'https://www.pixiv.net/ajax/user/{member_id}/illustmanga/tag?tag=R-18&offset={offset}&limit={limit}'
-            else:
-                url = f'https://www.pixiv.net/ajax/user/{member_id}/profile/all'
-                need_to_slice = True
+            # TODO: Find replacement for tag search!
+            #if len(tags) > 0:  # called from Download by tags
+            #    url = f'https://www.pixiv.net/ajax/user/{member_id}/illustmanga/tag?tag={tags}&offset={offset}&limit={limit}'
+            #elif r18mode:
+            #    url = f'https://www.pixiv.net/ajax/user/{member_id}/illustmanga/tag?tag=R-18&offset={offset}&limit={limit}'
+            #else:
+            url = f'https://www.pixiv.net/ajax/user/{member_id}/profile/all'
+            need_to_slice = True
 
             PixivHelper.print_and_log('info', f'{Fore.LIGHTGREEN_EX}{"Member Url":14}:{Style.RESET_ALL} {url}')
 

--- a/PixivBrowserFactory.py
+++ b/PixivBrowserFactory.py
@@ -845,6 +845,8 @@ class PixivBrowser(mechanize.Browser):
                         raise PixivException(msg, errorCode=PixivException.NOT_LOGGED_IN, htmlPage=errorMessage)
                     elif errorCode == 403:
                         raise PixivException(msg, errorCode=PixivException.USER_ID_SUSPENDED, htmlPage=errorMessage)
+                    elif errorCode == 404:
+                        raise PixivException(msg, errorCode=PixivException.USER_ID_NOT_EXISTS, htmlPage=errorMessage)
                     else:
                         raise PixivException(msg, errorCode=PixivException.OTHER_MEMBER_ERROR, htmlPage=errorMessage)
 

--- a/PixivBrowserFactory.py
+++ b/PixivBrowserFactory.py
@@ -822,15 +822,16 @@ class PixivBrowser(mechanize.Browser):
             if response is None:
                 try:
                     res = self.open_with_retry(url)
-                    response = res.read()
+                    response_str = res.read()
                     res.close()
+                    response = json.loads(response_str)
                 except urllib.error.HTTPError as ex:
                     if ex.code == 404:
                         response = ex.read()
                 self._put_to_cache(url, response)
 
             PixivHelper.get_logger().debug(response)
-            artist = PixivArtist(member_id, response, False, offset, limit)
+            artist = PixivArtist(member_id, response["body"], False, offset, limit)
 
             # fix issue with member with 0 images, skip everything.
             if len(artist.imageList) == 0 and throw_empty_error:

--- a/PixivBrowserFactory.py
+++ b/PixivBrowserFactory.py
@@ -729,27 +729,28 @@ class PixivBrowser(mechanize.Browser):
                     res.close()
                     info = json.loads(infoStr)
                     self._put_to_cache(url, info)
-            else:
-                PixivHelper.print_and_log('info', f'Using OAuth to retrieve member info for: {member_id}')
-                if not self._username or not self._password:
-                    raise PixivException("Empty Username or Password, remove cookie value and relogin, or add username/password to config.ini.")
-
-                url = f'https://app-api.pixiv.net/v1/user/detail?user_id={member_id}'
-                info = self._get_from_cache(url)
-                if info is None:
-                    PixivHelper.get_logger().debug("Getting member information: %s", member_id)
-                    login_response = self._oauth_manager.login()
-                    if login_response.status_code == 200:
-                        info = json.loads(login_response.text)
-                        if self._config.refresh_token != info["response"]["refresh_token"]:
-                            PixivHelper.print_and_log('info', 'OAuth Refresh Token is updated, updating config.ini')
-                            self._config.refresh_token = info["response"]["refresh_token"]
-                            self._config.writeConfig(path=self._config.configFileLocation)
-
-                    response = self._oauth_manager.get_user_info(member_id)
-                    info = json.loads(response.text)
-                    self._put_to_cache(url, info)
-                    PixivHelper.get_logger().debug("reply: %s", response.text)
+             # TODO: Find substitution for artists without images.
+#            else:
+#                PixivHelper.print_and_log('info', f'Using OAuth to retrieve member info for: {member_id}')
+#                if not self._username or not self._password:
+#                    raise PixivException("Empty Username or Password, remove cookie value and relogin, or add username/password to config.ini.")
+#
+#                url = f'https://app-api.pixiv.net/v1/user/detail?user_id={member_id}'
+#                info = self._get_from_cache(url)
+#                if info is None:
+#                    PixivHelper.get_logger().debug("Getting member information: %s", member_id)
+#                    login_response = self._oauth_manager.login()
+#                    if login_response.status_code == 200:
+#                        info = json.loads(login_response.text)
+#                        if self._config.refresh_token != info["response"]["refresh_token"]:
+#                            PixivHelper.print_and_log('info', 'OAuth Refresh Token is updated, updating config.ini')
+#                            self._config.refresh_token = info["response"]["refresh_token"]
+#                            self._config.writeConfig(path=self._config.configFileLocation)
+#
+#                    response = self._oauth_manager.get_user_info(member_id)
+#                    info = json.loads(response.text)
+#                    self._put_to_cache(url, info)
+#                    PixivHelper.get_logger().debug("reply: %s", response.text)
 
             artist.ParseInfo(info, False, bookmark=bookmark)
 
@@ -801,19 +802,18 @@ class PixivBrowser(mechanize.Browser):
             # https://www.pixiv.net/ajax/user/1039353/illusts/bookmarks?tag=&offset=0&limit=24&rest=show
             url = f'https://www.pixiv.net/ajax/user/{member_id}/illusts/bookmarks?tag={tags}&offset={offset}&limit={limit}&rest=show'
         else:
-            # https://www.pixiv.net/ajax/user/1813972/illusts/tag?tag=Fate%2FGrandOrder?offset=0&limit=24
-            # https://www.pixiv.net/ajax/user/1813972/manga/tag?tag=%E3%83%A1%E3%82%A4%E3%82%AD%E3%83%B3%E3%82%B0?offset=0&limit=24
+            # https://www.pixiv.net/ajax/user/1813972/illustmanga/tag?tag=Fate%2FGrandOrder?offset=0&limit=24
+            # https://www.pixiv.net/ajax/user/1813972/illustmanga/tag?tag=%E3%83%A1%E3%82%A4%E3%82%AD%E3%83%B3%E3%82%B0?offset=0&limit=24
             # https://www.pixiv.net/ajax/user/5238/illustmanga/tag?tag=R-18&offset=0&limit=48
             # https://www.pixiv.net/ajax/user/1813972/profile/all
             url = None
-            # TODO: Find replacement for tag search!
-            #if len(tags) > 0:  # called from Download by tags
-            #    url = f'https://www.pixiv.net/ajax/user/{member_id}/illustmanga/tag?tag={tags}&offset={offset}&limit={limit}'
-            #elif r18mode:
-            #    url = f'https://www.pixiv.net/ajax/user/{member_id}/illustmanga/tag?tag=R-18&offset={offset}&limit={limit}'
-            #else:
-            url = f'https://www.pixiv.net/ajax/user/{member_id}/profile/all'
-            need_to_slice = True
+            if len(tags) > 0:  # called from Download by tags
+                url = f'https://www.pixiv.net/ajax/user/{member_id}/illustmanga/tag?tag={tags}&offset={offset}&limit={limit}'
+            elif r18mode:
+                url = f'https://www.pixiv.net/ajax/user/{member_id}/illustmanga/tag?tag=R-18&offset={offset}&limit={limit}'
+            else:
+                url = f'https://www.pixiv.net/ajax/user/{member_id}/profile/all'
+                need_to_slice = True
 
             PixivHelper.print_and_log('info', f'{Fore.LIGHTGREEN_EX}{"Member Url":14}:{Style.RESET_ALL} {url}')
 
@@ -826,9 +826,28 @@ class PixivBrowser(mechanize.Browser):
                     response_str = res.read()
                     res.close()
                     response = json.loads(response_str)
-                except urllib.error.HTTPError as ex:
-                    if ex.code == 404:
-                        response = ex.read()
+                except urllib.error.HTTPError as error:
+                    errorCode = error.getcode()
+                    errorMessage = error.get_data()
+                    PixivHelper.get_logger().error("Error data: \r\n %s", errorMessage)
+                    payload = demjson3.decode(errorMessage)
+
+                    msg = None
+                    if "message" in payload:
+                        msg = payload["message"]
+                    elif "error" in payload and payload["error"] is not None:
+                        msgs = list()
+                        msgs.append(payload["error"]["user_message"])
+                        msgs.append(payload["error"]["message"])
+                        msgs.append(payload["error"]["reason"])
+                        msg = ",".join(msgs)
+                    if errorCode == 401:
+                        raise PixivException(msg, errorCode=PixivException.NOT_LOGGED_IN, htmlPage=errorMessage)
+                    elif errorCode == 403:
+                        raise PixivException(msg, errorCode=PixivException.USER_ID_SUSPENDED, htmlPage=errorMessage)
+                    else:
+                        raise PixivException(msg, errorCode=PixivException.OTHER_MEMBER_ERROR, htmlPage=errorMessage)
+
                 self._put_to_cache(url, response)
 
             PixivHelper.get_logger().debug(response)

--- a/PixivImage.py
+++ b/PixivImage.py
@@ -131,7 +131,7 @@ class PixivImage (object):
             # parse artist information
             if parent is None:
                 temp_artist_id = int(payload["body"]["userId"])
-                self.artist = PixivArtist(temp_artist_id, payload_body, fromImage=True)
+                self.artist = PixivArtist(temp_artist_id, payload_body=payload_body, fromImage=True)
 
             if fromBookmark and self.originalArtist is None:
                 assert (self.artist is not None)


### PR DESCRIPTION
- Comment code that is no longer active in `PixivBrowserFactory.py` used to collect information from artists with no images due to OAuth (alledgedly) not longer working while also being stopped by a previous ExceptionHandler.
- Add an ExceptionHandler for artists without page due to suspension or because they left.
- Reduce `PixivArtist()` object from `PixivArtist.py` to avoid `ParseInfo()` when `payload` does not have the necessary data.
- Reduce `ParseInfo()` in `PixivArtist.py` to what is used (`"profile"` filter maybe could be further reduced).